### PR TITLE
Introduce an `ArrayLikeIterable` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,18 @@ Arrays implement this interface. Note however, that the array counterpart revers
 creating a new array.
 
 
+`ArrayLikeIterable`
+-------------------
+
+[ArrayLikeIterable]: #arraylikeiterable
+
+An iterable with Array-like iteration operations. Both `Array` and `AIterable` implement it.
+
+
 `AIterable`
 -----------
 
-This is an abstract class implementing [RevertibleIterable] interface and a subset of Array-like API.
+Abstract `Iterable` implementation with array-like iteration operations.
 
 
 ### `AIterable.none()`
@@ -82,7 +90,7 @@ expect(AIterable.none()[Symbol.iterator]().next().done).toBe(true);
 
 ### `AIterable.is()`
 
-Checks whether the source `Iterable` implements an `AIterable` interface.
+Checks whether the given iterable is an array-like one.
 
 ```TypeScript
 import { AIterable } from 'a-iterable';
@@ -94,7 +102,7 @@ AIterable.is({ *[Symbol.iterator]() { yield 'something'; } }); // false
 
 ### `AIterable.of()`
 
-Converts the source `Iterable` to `AIterable` if necessary.
+Creates an `AIterable` instance that iterates over the same elements as the given one if necessary.
 
 ```TypeScript
 import { AIterable } from 'a-iterable';
@@ -103,7 +111,7 @@ AIterable.of([1, 2, 3]);
 AIterable.of({ *[Symbol.iterator]() { yield 'something'; } });
 ```
 
-When called for the object already implementing `AIterable` (such as `Array`), this method returns the source
+When called for the object already implementing `ArrayLikeIterable` (such as `Array`), this method returns the source
 object itself.
 
 [AIterable.of()]: #aiterableof
@@ -111,12 +119,12 @@ object itself.
 
 ### `AIterable.from()`
 
-Converts the source `Iterable` to `AIterable`.
+Creates an `AIterable` instance that iterates over the same elements as the given one.
 
-Unlike [AIterable.of()] this function always creates new iterable instance. This may be useful when converting array 
+Unlike [AIterable.of()] this function always creates new `AIterable` instance. This may be useful when converting array 
 and iterating over its elements. This way new array instances won't be created.
 
-Uses [reverseIt()] function to revert the constructed iterable.
+Uses [reverseIt()] function to reverse the constructed iterable.
 
 ```TypeScript
 import { AIterable, itsFirst } from 'a-iterable';

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -53,7 +53,8 @@ module.exports = (config) => {
         'forceConsistentCasingInFileNames': false,
         'experimentalDecorators': true,
         'lib': [
-          'es6',
+          'es2015',
+          'esnext.array',
         ],
         'sourceMap': true,
         'newLine': 'LF'

--- a/src/a-iterable.spec.ts
+++ b/src/a-iterable.spec.ts
@@ -46,7 +46,7 @@ describe('AIterable', () => {
 
   describe('of', () => {
     it('returns array itself', () => {
-      expect<Iterable<number>>(AIterable.of(elements)).toBe(elements);
+      expect(AIterable.of(elements)).toBe(elements);
     });
     it('returns `AIterable` itself', () => {
       expect(AIterable.of(iter)).toBe(iter);

--- a/src/a-iterable.ts
+++ b/src/a-iterable.ts
@@ -1,13 +1,14 @@
+import { ArrayLikeIterable } from './array-like-iterable';
 import { itsRevertible, reverseArray, reverseIt, RevertibleIterable } from './revertible-iterable';
 import { itsEach, itsEvery, itsReduction } from './termination';
 import { filterIt, flatMapIt, mapIt } from './transform';
 
 /**
- * Abstract `Iterable` implementation with Array-like iteration operations.
+ * Abstract `Iterable` implementation with array-like iteration operations.
  *
  * @param <T> A type of elements.
  */
-export abstract class AIterable<T> implements RevertibleIterable<T> {
+export abstract class AIterable<T> implements ArrayLikeIterable<T> {
 
   /**
    * Returns an iterable without elements.
@@ -21,14 +22,14 @@ export abstract class AIterable<T> implements RevertibleIterable<T> {
   }
 
   /**
-   * Checks whether the given iterable implements an `AIterable` interface.
+   * Checks whether the given iterable is an array-like one.
    *
    * @param source An iterable to check.
    *
-   * @returns `true` is the `source` has all `AIterable` methods (like `Array` or `AIterable` instance),
+   * @returns `true` is the `source` has all `ArrayLikeIterable` methods (like `Array` or `AIterable` instance),
    * or `false` otherwise.
    */
-  static is<T>(source: Iterable<T> | RevertibleIterable<T>): source is AIterable<T> {
+  static is<T>(source: Iterable<T>): source is ArrayLikeIterable<T> {
     return 'every' in source
         && 'filter' in source
         && 'flatMap' in source
@@ -38,18 +39,18 @@ export abstract class AIterable<T> implements RevertibleIterable<T> {
         && itsRevertible(source);
   }
 
-  static of<T>(source: T[]): T[];
+  static of<T>(source: ArrayLikeIterable<T>): typeof source;
   static of<T>(source: Iterable<T>): AIterable<T>;
 
   /**
-   * Creates an `AIterable` instance that iterates over the same elements as the given one.
+   * Creates an `AIterable` instance that iterates over the same elements as the given one if necessary.
    *
    * @param source A source iterable.
    *
-   * @return Either `source` itself if it implements `AIterable` already (see `is()` method),
-   * or new `AIterable` instance.
+   * @return Either `source` itself if it implements `ArrayLikeIterable` already (see `is()` method),
+   * or new `AIterable` instance iterating over the `source`.
    */
-  static of<T>(source: Iterable<T> | RevertibleIterable<T> | T[]): AIterable<T> | T[] {
+  static of<T>(source: Iterable<T> | RevertibleIterable<T> | T[]): ArrayLikeIterable<T> {
     if (AIterable.is(source)) {
       return source;
     }
@@ -59,7 +60,7 @@ export abstract class AIterable<T> implements RevertibleIterable<T> {
   /**
    * Creates an `AIterable` instance that iterates over the same elements as the given one.
    *
-   * Uses `reverseIt()` function to revert the constructed iterable.
+   * Uses `reverseIt()` function to reverse the constructed iterable.
    *
    * @param source A source iterable.
    *
@@ -99,6 +100,9 @@ export abstract class AIterable<T> implements RevertibleIterable<T> {
     return itsEvery(this, test);
   }
 
+  filter(test: (element: T) => boolean): AIterable<T>;
+  filter<S extends T>(test: (element: T) => element is S): AIterable<S>;
+
   /**
    * Creates an iterable with all elements that pass the test implemented by the provided function.
    *
@@ -120,6 +124,9 @@ export abstract class AIterable<T> implements RevertibleIterable<T> {
    * First maps each element using a mapping function, then flattens the result into a new iterable.
    *
    * Corresponds to `Array.prototype.flatMap()`.
+   *
+   * Note that the overridden `flatMap` method of `ArrayLikeIterable` expects an array to be returned from `convert`
+   * callback, while in this method it may return arbitrary iterable.
    *
    * @param <R> A type of converted elements.
    * @param convert A function that produces a new iterable, taking the source element as the only parameter.

--- a/src/array-like-iterable.ts
+++ b/src/array-like-iterable.ts
@@ -1,0 +1,79 @@
+import { RevertibleIterable } from './revertible-iterable';
+
+/**
+ * An iterable with array-like iteration operations. Both `Array` and `AIterable` implement it.
+ *
+ * @param <T> A type of elements.
+ */
+export interface ArrayLikeIterable<T> extends RevertibleIterable<T> {
+
+  /**
+   * Determines whether all the element in this iterable satisfy the specified test.
+   *
+   * @param callbackfn A function that accepts an element as its only parameter. The `every` method calls the
+   * `callbackfn` function for each element until the `callbackfn` returns `false`, or until the end of iterable.
+   */
+  every(callbackfn: (value: T) => boolean): boolean;
+
+  /**
+   * Returns the elements of this iterable that meet the condition specified in a callback function.
+   *
+   * @param callbackfn A function that accepts an element as its only parameter. The `filter` method calls the
+   * `callbackfn` function one time for each element.
+   */
+  filter<S extends T>(callbackfn: (value: T) => value is S): ArrayLikeIterable<S>;
+
+  /**
+   * Returns the elements of this iterable that meet the condition specified in a callback function.
+   *
+   * @param callbackfn A function that accepts an element as its only parameter. The `filter` method calls the
+   * `callbackfn` function one time for each element.
+   */
+  filter(callbackfn: (value: T) => boolean): ArrayLikeIterable<T>;
+
+  /**
+   * Calls a defined callback function on each element in this iterable. Then, flattens the result.
+   *
+   * @param callback A function that accepts an element as its only parameter. The `flatMap` method calls the
+   * `callback` function one time for each element.
+   */
+  flatMap<U> (callback: (value: T) => ReadonlyArray<U>): ArrayLikeIterable<U>;
+
+  /**
+   * Performs the specified action for each element in this iterable.
+   *
+   * @param callbackfn A function that accepts an element as its only parameter. The `forEach` method calls the
+   * `callbackfn` function one time for each element.
+   */
+  forEach(callbackfn: (value: T) => void): void;
+
+  /**
+   * Calls a defined callback function on each element in this iterable, and returns an iterable that contains the
+   * results.
+   *
+   * @param callbackfn A function that an element as its only parameter. The `map` method calls the `callbackfn`
+   * function one time for each element.
+   */
+  map<U>(callbackfn: (value: T) => U): ArrayLikeIterable<U>;
+
+  /**
+   * Calls the specified callback function for all the elements in this iterable. The return value of the callback
+   * function is the accumulated result, and is provided as an argument in the next call to the callback function.
+   *
+   * @param callbackfn A function that accepts an accumulated value and an element as its parameters. The `reduce`
+   * method calls the `callbackfn` function one time for each element.
+   * @param initialValue Used as the initial value to start the accumulation. The first call to the `callbackfn`
+   * function provides this value as the first parameter.
+   */
+  reduce<U>(callbackfn: (previousValue: U, currentValue: T) => U, initialValue: U): U;
+
+  /**
+   * Returns an iterable containing this iterable's elements in reverse order.
+   *
+   * This method may reverse the elements _in place_, like arrays do.
+   *
+   * @return Reversed iterable instance.
+   */
+  reverse(): ArrayLikeIterable<T>;
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './a-iterable';
+export * from './array-like-iterable';
 export * from './construction';
 export * from './revertible-iterable';
 export * from './termination';

--- a/src/revertible-iterable.ts
+++ b/src/revertible-iterable.ts
@@ -6,7 +6,7 @@
 export interface RevertibleIterable<T> extends Iterable<T> {
 
   /**
-   * Constructs an iterable containing this iterable's elements in reverse order.
+   * Returns an iterable containing this iterable's elements in reverse order.
    *
    * Corresponds to `Array.prototype.reverse()`. Note however, that the array counterpart reverses elements _in place_
    * rather than creating a new array.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "importHelpers": true,
     "noEmitHelpers": true,
     "lib": [
-      "es2015"
+      "es2015",
+      "esnext.array"
     ],
     "outDir": "target/js",
     "sourceMap": true,


### PR DESCRIPTION
Better reflects an Array API. Namely, an `Array.flatMap()` expects
a callback function to return an Array. While `AIterable` expects
an arbitrary `Iterable`.

`AIterable.of()` returns an `ArrayLikeIterable` now.